### PR TITLE
Switch from ini format to Python syntax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v0.9.0
+======
+
+#1: Instead of an ini file, this plugin now discovers the
+tests from any function with "perf" in the function name.
+See "exercises.py" in this repo for a demo of the syntax.
+
 v0.8.0
 ======
 

--- a/exercises.ini
+++ b/exercises.ini
@@ -1,6 +1,0 @@
-[sample test]
-warmup = import abc
-exercise = dir(abc)
-extras = testing
-deps =
-	path

--- a/exercises.py
+++ b/exercises.py
@@ -3,8 +3,18 @@ from pytest_perf.deco import extras, deps
 
 @extras('testing')
 @deps('path')
-def sample_test_perf():
-    "sample test"
+def deps_and_extras_perf():
+    "with deps and extras"
+    import path
+    import pytest  # end warmup
+
+    assert type(pytest) is type(path)
+
+
+def simple_perf_test():
+    "simple test"
     import abc
-    # exercise
+    import types  # end warmup
+
     dir(abc)
+    assert isinstance(abc, types.ModuleType)

--- a/exercises.py
+++ b/exercises.py
@@ -1,0 +1,10 @@
+from pytest_perf.deco import extras, deps
+
+
+@extras('testing')
+@deps('path')
+def sample_test_perf():
+    "sample test"
+    import abc
+    # exercise
+    dir(abc)

--- a/pytest_perf/deco.py
+++ b/pytest_perf/deco.py
@@ -5,10 +5,12 @@ def decorate(name, *items):
     """
     Build a decorator to extend a list of items on a function.
     """
+
     def apply(func):
         values = vars(func).setdefault(name, [])
         values.extend(items)
         return func
+
     return apply
 
 

--- a/pytest_perf/deco.py
+++ b/pytest_perf/deco.py
@@ -1,0 +1,16 @@
+import functools
+
+
+def decorate(name, *items):
+    """
+    Build a decorator to extend a list of items on a function.
+    """
+    def apply(func):
+        values = vars(func).setdefault(name, [])
+        values.extend(items)
+        return func
+    return apply
+
+
+extras = functools.partial(decorate, 'extras')
+deps = functools.partial(decorate, 'deps')

--- a/pytest_perf/plugin.py
+++ b/pytest_perf/plugin.py
@@ -48,9 +48,7 @@ def funcs_from_name(name):
     mod_name = mod_path.replace('/', '.')
     mod = importlib.import_module(mod_name)
     return (
-        getattr(mod, name)
-        for name in dir(mod)
-        if re.search(r'(\b|_)perf(\b|_)', name)
+        getattr(mod, name) for name in dir(mod) if re.search(r'(\b|_)perf(\b|_)', name)
     )
 
 

--- a/pytest_perf/plugin.py
+++ b/pytest_perf/plugin.py
@@ -1,21 +1,25 @@
 import pytest
-import configparser
 import functools
+import importlib
+import re
+import inspect
+import textwrap
+import contextlib
 
 from typing import List
-from jaraco.functools import assign_params
+from jaraco.functools import assign_params, pass_none, apply
 from more_itertools import peekable
 
 from pytest_perf import runner
 
 
 def pytest_collect_file(parent, path):
-    if path.basename == 'exercises.ini':
+    if path.basename.endswith('.py'):
         return File.from_parent(parent, fspath=path)
 
 
 def pytest_terminal_summary(terminalreporter, config):
-    items = peekable(filter(None, Item._instances))
+    items = peekable(filter(None, Experiment._instances))
     items and terminalreporter.section('perf')
     for line in map(str, items):
         terminalreporter.write_line(line)
@@ -30,25 +34,57 @@ def pytest_sessionfinish():
 
 class File(pytest.File):
     def collect(self):
-        config = configparser.ConfigParser()
-        config.read(self.fspath)
         return (
-            Item.from_parent(self, name=section, spec=config[section])
-            for section in config.sections()
+            Experiment.from_parent(self, name=f'{self.name}:{spec["name"]}', spec=spec)
+            for spec in map(spec_from_func, funcs_from_name(self.name))
         )
 
 
 runner_factory = functools.lru_cache()(runner.BenchmarkRunner)
 
 
-class Item(pytest.Item):
-    _instances: 'List[Item]' = []
+def funcs_from_name(name):
+    mod_path, sep, rest = name.rpartition('.')
+    mod_name = mod_path.replace('/', '.')
+    mod = importlib.import_module(mod_name)
+    return (
+        getattr(mod, name)
+        for name in dir(mod)
+        if re.search(r'(\b|_)perf(\b|_)', name)
+    )
+
+
+def first_line(text):
+    lines = (line.strip() for line in text.splitlines())
+    return next(lines, None)
+
+
+freeze = pass_none(tuple)
+
+
+@apply(dict)
+def spec_from_func(_func):
+    yield 'name', (first_line(_func.__doc__) or _func.__name__)
+    with contextlib.suppress(AttributeError):
+        yield 'extras', freeze(_func.extras)
+    with contextlib.suppress(AttributeError):
+        yield 'deps', freeze(_func.deps)
+    _header, _sep, _body_ind = inspect.getsource(_func).partition(':\n')
+    _body = textwrap.dedent(_body_ind)
+    warmup, sep, exercise = _body.rpartition('# end warmup')
+    if warmup:
+        yield 'warmup', warmup
+    yield 'exercise', exercise
+
+
+class Experiment(pytest.Item):
+    _instances: 'List[Experiment]' = []
 
     def __init__(self, name, parent, spec):
         super().__init__(name, parent)
         self.spec = spec
         self.command = assign_params(runner.Command, spec)()
-        Item._instances.append(self)
+        Experiment._instances.append(self)
 
     def runtest(self):
         self.results = self.runner.run(self.command)

--- a/pytest_perf/runner.py
+++ b/pytest_perf/runner.py
@@ -73,12 +73,11 @@ class BenchmarkRunner:
     Result('...', '...')
     """
 
-    def __init__(self, extras=None, deps=None):
-        spec = f'[{extras}]' if extras else ''
-        addl = filter(None, deps.splitlines()) if deps else []
+    def __init__(self, extras=(), deps=()):
+        spec = f'[{",".join(extras)}]' if extras else ''
         self.stack = contextlib.ExitStack()
-        self.baseline_env = self._setup_env(upstream_url(spec), *addl)
-        self.local_env = self._setup_env(f'.{spec}', *addl)
+        self.baseline_env = self._setup_env(upstream_url(spec), *deps)
+        self.local_env = self._setup_env(f'.{spec}', *deps)
 
     def _setup_env(self, *deps):
         target = self.stack.enter_context(pip_run.deps.load(*deps))


### PR DESCRIPTION
I wasn't happy with the ini format. It was too constraining and unintuitive. This new approach allows the tests to be written as simple Python functions and extracts the warmup and exercise code from those functions and provides decorators to supply other configuration.