### PR TITLE
Allow installing from an existing wheel

### DIFF
--- a/pytest_perf/plugin.py
+++ b/pytest_perf/plugin.py
@@ -14,11 +14,37 @@ from more_itertools import peekable
 from pytest_perf import runner
 
 
-def pytest_collect_file(parent, path):
+def pytest_addoption(parser):
+    group = parser.getgroup("performance tests (pytest-perf)")
+    group.addoption(
+        "--perf-target",
+        dest="perf_target",
+        default=".",
+        action="store",
+        help="directory or distribution file for which the performance tests will run"
+        " (default: %(default)r)",
+    )
+    group.addoption(
+        "--perf-baseline",
+        dest="perf_baseline",
+        default=None,
+        action="store",
+        help="URL to a git repository that will be used as a performance comparison. "
+        "When not provided the value of the `origin` remote will be used",
+    )
+
+
+def pytest_collect_file(path, parent):
+    config = parent.config
     if path.basename.endswith('.py') and 'pytest_perf' in path.read_text(
         encoding='utf-8'
     ):
-        return File.from_parent(parent, fspath=path)
+        return File.from_parent(
+            parent,
+            fspath=path,
+            target=config.getoption("perf_target"),
+            baseline=config.getoption("perf_baseline"),
+        )
 
 
 def pytest_terminal_summary(terminalreporter, config):
@@ -36,9 +62,18 @@ def pytest_sessionfinish():
 
 
 class File(pytest.File):
+    def __init__(self, fspath, parent, target=".", baseline=None):
+        super().__init__(fspath, parent)
+        self.target = target
+        self.baseline = baseline
+
     def collect(self):
         return (
-            Experiment.from_parent(self, name=f'{self.name}:{spec["name"]}', spec=spec)
+            Experiment.from_parent(
+                self,
+                name=f'{self.name}:{spec["name"]}',
+                spec={"target": self.target, "baseline": self.baseline, **spec},
+            )
             for spec in map(spec_from_func, funcs_from_name(self.name))
         )
 

--- a/pytest_perf/runner.py
+++ b/pytest_perf/runner.py
@@ -132,10 +132,14 @@ def upstream_package(
     url = url or upstream_url()
     rev: List[str] = ['--branch', control] if control else []
     with tempfile.TemporaryDirectory() as tmp:
-        cmd = ['git', 'clone', *rev, url, str(tmp)]
+        cmd = ['git', 'clone', '--depth', '1', *rev, url, str(tmp)]
         subprocess.run(cmd, check=True, **_text)  # type: ignore
         with local_package(tmp) as target:
             yield target
+
+            if os.name == "nt":
+                # Avoid cleanup errors on Windows
+                subprocess.run("rmdir /S /Q .git", shell=True, check=False)
 
 
 @contextlib.contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["pytester"]

--- a/tests/pypi_helpers.py
+++ b/tests/pypi_helpers.py
@@ -1,0 +1,69 @@
+import json
+import re
+from hashlib import md5
+from itertools import chain
+from pathlib import Path
+from typing import Iterator, List
+from urllib.request import urlopen
+
+
+HERE = Path(__file__).parent
+DOWNLOADS = HERE / ".downloads"
+
+
+def download_dists(package: str, version: str) -> List[Path]:
+    """Either use cached dist file or download it from PyPI"""
+    DOWNLOADS.mkdir(exist_ok=True)
+
+    distributions = retrieve_pypi_dist_metadata(package, version)
+    filenames = {dist["filename"] for dist in distributions}
+
+    # Remove old files to prevent cache to grow indefinitely
+    canonical = canonicalize_name(package)
+    names = [package, canonical, canonical.replace("-", "_")]
+    for file in chain.from_iterable(DOWNLOADS.glob(f"{n}*") for n in names):
+        if file.name not in filenames:
+            file.unlink()
+
+    dist_files = []
+    for dist in retrieve_pypi_dist_metadata(package, version):
+        dest = DOWNLOADS / dist["filename"]
+        if not dest.exists():
+            download(dist["url"], dest, dist["md5_digest"])
+        dist_files.append(dest)
+
+    return dist_files
+
+
+def retrieve_pypi_dist_metadata(package: str, version: str) -> Iterator[dict]:
+    # https://warehouse.pypa.io/api-reference/json.html
+    id_ = f"{package}/{version}"
+    with urlopen(f"https://pypi.org/pypi/{id_}/json") as f:
+        metadata = json.load(f)
+
+    if metadata["info"]["yanked"]:
+        raise ValueError(f"Release for {package} {version} was yanked")
+
+    version = metadata["info"]["version"]
+    for dist in metadata["releases"][version]:
+        if any(dist["filename"].endswith(ext) for ext in (".tar.gz", ".whl")):
+            yield dist
+
+
+def canonicalize_name(name: str) -> str:
+    # PEP 503.
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def download(url: str, dest: Path, md5_digest: str) -> Path:
+    with urlopen(url) as f:
+        data = f.read()
+
+    assert md5(data).hexdigest() == md5_digest
+
+    with open(dest, "wb") as f:
+        f.write(data)
+
+    assert dest.exists()
+
+    return dest

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,16 +4,23 @@ from .pypi_helpers import download_dists
 
 
 @pytest.mark.parametrize(
-    "target, baseline, extras",
+    "target, baseline, extras, test_code",
     [
         [
             ("setuptools_scm", "6.0.0"),
             ("https://github.com/pypa/setuptools_scm.git", "v6.4.2"),
             "toml",
-        ]
+            "import setuptools_scm",
+        ],
+        [
+            ("jaraco.context", "3.0.0"),
+            ("https://github.com/jaraco/jaraco.context", "v4.1.1"),
+            "",
+            "from jaraco import context",
+        ],
     ],
 )
-def test_example(testdir, target, baseline, extras):
+def test_example(testdir, target, baseline, extras, test_code):
     """Make sure pytest-perf can be configured"""
     package, version = target
     url, control = baseline
@@ -26,7 +33,7 @@ def test_example(testdir, target, baseline, extras):
         @extras({extras!r})
         @control({control!r})
         def simple():
-            pass
+            {test_code}
         """
         testdir.makepyfile(test)
         result = testdir.runpytest(*args)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,33 @@
+import pytest
+
+from .pypi_helpers import download_dists
+
+
+@pytest.mark.parametrize(
+    "target, baseline, extras",
+    [
+        [
+            ("setuptools_scm", "6.0.0"),
+            ("https://github.com/pypa/setuptools_scm.git", "v6.4.2"),
+            "toml",
+        ]
+    ],
+)
+def test_example(testdir, target, baseline, extras):
+    """Make sure pytest-perf can be configured"""
+    package, version = target
+    url, control = baseline
+
+    for dist in download_dists(package, version):
+        args = ["--perf-target", str(dist), "--perf-baseline", url]
+        test = f"""
+        from pytest_perf.deco import extras, control
+
+        @extras({extras!r})
+        @control({control!r})
+        def simple():
+            pass
+        """
+        testdir.makepyfile(test)
+        result = testdir.runpytest(*args)
+        result.assert_outcomes(errors=0)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -64,7 +64,13 @@ def test_upstream_package(url, rev, extras, tmp_path):
             ("https://github.com/pypa/setuptools_scm.git", "v6.4.2"),
             ["toml"],
             "import setuptools_scm",
-        ]
+        ],
+        [
+            ("jaraco.context", "3.0.0"),
+            ("https://github.com/jaraco/jaraco.context", "v4.1.1"),
+            [],
+            "from jaraco import context",
+        ],
     ],
 )
 def test_benchmark_runner(target, baseline, extras, command):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,19 +1,11 @@
-import json
-import re
 import subprocess
 import sys
-from hashlib import md5
-from itertools import chain
-from pathlib import Path
-from typing import Iterator, List
-from urllib.request import urlopen
 
 import pytest
 
 from pytest_perf.runner import BenchmarkRunner, Command, local_package, upstream_package
 
-HERE = Path(__file__).parent
-DOWNLOADS = HERE / ".downloads"
+from .pypi_helpers import download_dists
 
 
 @pytest.mark.parametrize(
@@ -83,64 +75,3 @@ def test_benchmark_runner(target, baseline, extras, command):
     for dist in download_dists(package, version):
         runner = BenchmarkRunner(extras, (), control, str(dist), url)
         runner.run(cmd)
-
-
-# --- Helper Functions ---
-
-
-def download_dists(package: str, version: str) -> List[Path]:
-    """Either use cached dist file or download it from PyPI"""
-    DOWNLOADS.mkdir(exist_ok=True)
-
-    distributions = retrieve_pypi_dist_metadata(package, version)
-    filenames = {dist["filename"] for dist in distributions}
-
-    # Remove old files to prevent cache to grow indefinitely
-    canonical = canonicalize_name(package)
-    names = [package, canonical, canonical.replace("-", "_")]
-    for file in chain.from_iterable(DOWNLOADS.glob(f"{n}*") for n in names):
-        if file.name not in filenames:
-            file.unlink()
-
-    dist_files = []
-    for dist in retrieve_pypi_dist_metadata(package, version):
-        dest = DOWNLOADS / dist["filename"]
-        if not dest.exists():
-            download(dist["url"], dest, dist["md5_digest"])
-        dist_files.append(dest)
-
-    return dist_files
-
-
-def retrieve_pypi_dist_metadata(package: str, version: str) -> Iterator[dict]:
-    # https://warehouse.pypa.io/api-reference/json.html
-    id_ = f"{package}/{version}"
-    with urlopen(f"https://pypi.org/pypi/{id_}/json") as f:
-        metadata = json.load(f)
-
-    if metadata["info"]["yanked"]:
-        raise ValueError(f"Release for {package} {version} was yanked")
-
-    version = metadata["info"]["version"]
-    for dist in metadata["releases"][version]:
-        if any(dist["filename"].endswith(ext) for ext in (".tar.gz", ".whl")):
-            yield dist
-
-
-def canonicalize_name(name: str) -> str:
-    # PEP 503.
-    return re.sub(r"[-_.]+", "-", name).lower()
-
-
-def download(url: str, dest: Path, md5_digest: str) -> Path:
-    with urlopen(url) as f:
-        data = f.read()
-
-    assert md5(data).hexdigest() == md5_digest
-
-    with open(dest, "wb") as f:
-        f.write(data)
-
-    assert dest.exists()
-
-    return dest

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,146 @@
+import json
+import re
+import subprocess
+import sys
+from hashlib import md5
+from itertools import chain
+from pathlib import Path
+from typing import Iterator, List
+from urllib.request import urlopen
+
+import pytest
+
+from pytest_perf.runner import BenchmarkRunner, Command, local_package, upstream_package
+
+HERE = Path(__file__).parent
+DOWNLOADS = HERE / ".downloads"
+
+
+@pytest.mark.parametrize(
+    "package, version, extras",
+    [
+        ("build", "0.7.0", ""),
+        ("build", "0.7.0", "[virtualenv]"),
+    ],
+)
+def test_local_package(package, version, extras, tmp_path):
+    # Ensure local packages can be installed with/without extras
+    for dist in download_dists(package, version):
+        with local_package(str(dist)) as pkg:
+            installable = f"{pkg}{extras}"
+            cmd = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-t",
+                str(tmp_path),
+                installable,
+            ]
+            subprocess.run(cmd, check=True)
+
+
+@pytest.mark.parametrize(
+    "url, rev, extras",
+    [
+        ("https://github.com/pypa/setuptools_scm.git", "v6.0.0", ""),
+        ("https://github.com/pypa/setuptools_scm", "v6.4.2", "[toml]"),
+        (None, None, ""),
+    ],
+)
+def test_upstream_package(url, rev, extras, tmp_path):
+    # Ensure remote VCS packages can be installed with/without extras
+    with upstream_package(url, rev) as pkg:
+        installable = f"{pkg}{extras}"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-t",
+            str(tmp_path),
+            installable,
+        ]
+        subprocess.run(cmd, check=True)
+
+
+@pytest.mark.parametrize(
+    "target, baseline, extras, command",
+    [
+        [
+            ("setuptools_scm", "6.0.0"),
+            ("https://github.com/pypa/setuptools_scm.git", "v6.4.2"),
+            ["toml"],
+            "import setuptools_scm",
+        ]
+    ],
+)
+def test_benchmark_runner(target, baseline, extras, command):
+    package, version = target
+    url, control = baseline
+    cmd = Command(command)
+
+    for dist in download_dists(package, version):
+        runner = BenchmarkRunner(extras, (), control, str(dist), url)
+        runner.run(cmd)
+
+
+# --- Helper Functions ---
+
+
+def download_dists(package: str, version: str) -> List[Path]:
+    """Either use cached dist file or download it from PyPI"""
+    DOWNLOADS.mkdir(exist_ok=True)
+
+    distributions = retrieve_pypi_dist_metadata(package, version)
+    filenames = {dist["filename"] for dist in distributions}
+
+    # Remove old files to prevent cache to grow indefinitely
+    canonical = canonicalize_name(package)
+    names = [package, canonical, canonical.replace("-", "_")]
+    for file in chain.from_iterable(DOWNLOADS.glob(f"{n}*") for n in names):
+        if file.name not in filenames:
+            file.unlink()
+
+    dist_files = []
+    for dist in retrieve_pypi_dist_metadata(package, version):
+        dest = DOWNLOADS / dist["filename"]
+        if not dest.exists():
+            download(dist["url"], dest, dist["md5_digest"])
+        dist_files.append(dest)
+
+    return dist_files
+
+
+def retrieve_pypi_dist_metadata(package: str, version: str) -> Iterator[dict]:
+    # https://warehouse.pypa.io/api-reference/json.html
+    id_ = f"{package}/{version}"
+    with urlopen(f"https://pypi.org/pypi/{id_}/json") as f:
+        metadata = json.load(f)
+
+    if metadata["info"]["yanked"]:
+        raise ValueError(f"Release for {package} {version} was yanked")
+
+    version = metadata["info"]["version"]
+    for dist in metadata["releases"][version]:
+        if any(dist["filename"].endswith(ext) for ext in (".tar.gz", ".whl")):
+            yield dist
+
+
+def canonicalize_name(name: str) -> str:
+    # PEP 503.
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def download(url: str, dest: Path, md5_digest: str) -> Path:
+    with urlopen(url) as f:
+        data = f.read()
+
+    assert md5(data).hexdigest() == md5_digest
+
+    with open(dest, "wb") as f:
+        f.write(data)
+
+    assert dest.exists()
+
+    return dest

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
 	pytest {posargs}
 passenv =
 	HOME
+	with-ssh-agent: SSH_AUTH_SOCK
 usedevelop = True
 extras = testing
 


### PR DESCRIPTION
Recently when playing around with the idea proposed in https://github.com/pypa/setuptools/pull/3015#pullrequestreview-847184271, I noticed that `pytest-perf` requires the package to be installed from `.`.

However, as proposed in the linked comment, not all projects will perform tests by installing from `.`. Some will try to use a pre-build distribution.

Would it be possible for `pytest-perf` to allow some sort of configuration for that?

In this PR I am suggesting something very simple based on an environment var: `PYTEST_PERF_WHEEL_TARGET` (that allows only wheels since their name is normalized and easy to extract from the file path).

Please let me know if you find this interesting. I don't know how to add unit tests, but this patch seems to work as show by [these CI logs](https://github.com/abravalheri/setuptools/runs/4909924109?check_suite_focus=true#step:7:8) that use [this configuration](https://github.com/abravalheri/setuptools/blob/c49ce3012169652b045743ef6936e502e07b8e8a/tox.ini#L8-L25).