### PR TITLE
Strip ANSI escapes before parsing timeit output (fixes colorized timeit on 3.15)

### DIFF
--- a/newsfragments/20.bugfix.rst
+++ b/newsfragments/20.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``AttributeError`` parsing colorized ``timeit`` output on Python 3.15 (with color enabled) by stripping ANSI escape sequences before matching.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 	"jaraco.context",
 	"packaging",
 	"jaraco.compat >= 4.1",
+	"jaraco.text >= 4.3",
 ]
 dynamic = ["version"]
 

--- a/pytest_perf/runner.py
+++ b/pytest_perf/runner.py
@@ -7,6 +7,7 @@ import tempfile
 import pip_run
 import tempora
 from jaraco.compat.py38 import r_fix
+from jaraco.text import strip_ansi
 
 
 class Command(list):
@@ -93,7 +94,9 @@ class BenchmarkRunner:
             out = subprocess.check_output(
                 cmd, cwd=empty, encoding='utf-8', text=True, **kwargs
             )
-        val = re.search(r'([0-9.]+ \w+) per loop', out).group(1)
+        # Python 3.15+ colorizes timeit output when color is enabled (e.g.
+        # FORCE_COLOR); strip escape sequences before parsing. jaraco/pytest-perf#20
+        val = re.search(r'([0-9.]+ \w+) per loop', strip_ansi(out)).group(1)
         return val
 
 


### PR DESCRIPTION
Fixes #20.

Python 3.15 colorizes `python -m timeit` output when color is enabled
([python/cpython#146609](https://github.com/python/cpython/issues/146609),
new in 3.15.0a8). With `FORCE_COLOR` set (as in many CI environments), the
output becomes:

```
'100000000 loops, best of 5: \x1b[1;32m3.24 nsec\x1b[0m \x1b[32mper loop\x1b[0m\n'
```

The ANSI escapes sit between the timing and `per loop`, so
`BenchmarkRunner.eval`'s `([0-9.]+ \w+) per loop` regex no longer matches,
`re.search` returns `None`, and `.group(1)` raises `AttributeError`.

This strips ANSI escape sequences (via the new `jaraco.text.strip_ansi`,
released in jaraco.text 4.3.0) before parsing.

Discovered via setuptools' CI on Python 3.15 (`exercises.py::measure_startup_perf`).
