### PR TITLE
Add type annotations and py.typed marker

### DIFF
--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,0 +1,1 @@
+Added type annotations and a ``py.typed`` marker so downstream projects can type-check against pytest-perf. (#16)

--- a/pytest_perf/deco.py
+++ b/pytest_perf/deco.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import functools
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_F = TypeVar('_F', bound=Callable[..., Any])
 
 
-def decorate(name, *items):
+def decorate(name: str, *items: Any) -> Callable[[_F], _F]:
     """
     Build a decorator to extend a list of items on a function.
     """
 
-    def apply(func):
+    def apply(func: _F) -> _F:
         values = vars(func).setdefault(name, [])
         values.extend(items)
         return func
@@ -18,9 +24,9 @@ extras = functools.partial(decorate, 'extras')
 deps = functools.partial(decorate, 'deps')
 
 
-def control(rev):
-    def apply(func):
-        func.control = rev
+def control(rev: str) -> Callable[[_F], _F]:
+    def apply(func: _F) -> _F:
+        func.control = rev  # type: ignore[attr-defined]
         return func
 
     return apply

--- a/pytest_perf/plugin.py
+++ b/pytest_perf/plugin.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import importlib
 import inspect
 import re
 import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 import pytest
 from jaraco.context import suppress
@@ -14,7 +20,7 @@ from packaging.version import Version
 from pytest_perf import runner
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("performance tests (pytest-perf)")
     group.addoption(
         "--perf-target",
@@ -27,18 +33,20 @@ def pytest_addoption(parser):
     )
 
 
-def _collect_file_pytest7(parent, file_path):
+def _collect_file_pytest7(parent: pytest.Collector, file_path: Path) -> File | None:
     if file_path.suffix == '.py' and 'pytest_perf' in file_path.read_text(
         encoding='utf-8'
     ):
         return File.from_parent(parent, path=file_path)
+    return None
 
 
-def _collect_file_pytest6(parent, path):
+def _collect_file_pytest6(parent: pytest.Collector, path: Any) -> File | None:
     if path.basename.endswith('.py') and 'pytest_perf' in path.read_text(
         encoding='utf-8'
     ):
         return File.from_parent(parent, fspath=path)
+    return None
 
 
 old_pytest = Version(pytest.__version__) < Version('7')
@@ -47,14 +55,16 @@ pytest_collect_file = suppress(UnicodeDecodeError)(
 )
 
 
-def pytest_terminal_summary(terminalreporter, config):
+def pytest_terminal_summary(
+    terminalreporter: pytest.TerminalReporter, config: pytest.Config
+) -> None:
     items = peekable(filter(None, Experiment._instances))
-    items and terminalreporter.section('perf')
+    items and terminalreporter.section('perf')  # type: ignore[func-returns-value] # side effect
     for line in map(str, items):
         terminalreporter.write_line(line)
 
 
-def pytest_sessionfinish():
+def pytest_sessionfinish() -> None:
     """
     Clear the runner factory to tear down any BenchmarkRunners.
     """
@@ -62,7 +72,7 @@ def pytest_sessionfinish():
 
 
 class File(pytest.File):
-    def collect(self):
+    def collect(self) -> Iterator[Experiment]:
         return (
             Experiment.from_parent(self, name=f'{self.name}:{spec["name"]}', spec=spec)
             for spec in map(spec_from_func, funcs_from_name(self.path))
@@ -73,14 +83,14 @@ runner_factory = functools.lru_cache()(runner.BenchmarkRunner)
 
 
 @suppress(Exception)
-def load_module(path):
+def load_module(path: Path) -> ModuleType:
     spec = importlib.util.spec_from_file_location(path.stem, path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type] # suppressed
+    spec.loader.exec_module(mod)  # type: ignore[union-attr] # suppressed
     return mod
 
 
-def funcs_from_name(path):
+def funcs_from_name(path: Path) -> Iterator[Any]:
     mod = load_module(path)
     return (
         getattr(mod, name) for name in dir(mod) if re.search(r'(\b|_)perf(\b|_)', name)
@@ -88,7 +98,7 @@ def funcs_from_name(path):
 
 
 @pass_none
-def first_line(text):
+def first_line(text: str) -> str | None:
     lines = (line.strip() for line in text.splitlines())
     return next(lines, None)
 
@@ -97,7 +107,7 @@ freeze = pass_none(tuple)
 
 
 @apply(dict)
-def spec_from_func(_func):
+def spec_from_func(_func: Any) -> Iterator[tuple[str, Any]]:
     r"""
     Given a function from an experiment file, return a
     spec (dictionary) representing that experiment.
@@ -135,20 +145,20 @@ def spec_from_func(_func):
 
 
 class Experiment(pytest.Item):
-    _instances: 'list[Experiment]' = []
-    results = None
+    _instances: list[Experiment] = []
+    results: runner.Result | None = None
 
-    def __init__(self, name, parent, spec):
+    def __init__(self, name: str, parent: pytest.Collector, spec: dict[str, Any]):
         super().__init__(name, parent)
         self.spec = spec
         self.command = assign_params(runner.Command, spec)()
         Experiment._instances.append(self)
 
-    def runtest(self):
+    def runtest(self) -> None:
         self.results = self.runner.run(self.command)
 
     @property
-    def config_params(self):
+    def config_params(self) -> dict[str, Any]:
         return {
             key.partition('perf_')[-1]: value
             for key, value in vars(self.config.known_args_namespace).items()
@@ -161,11 +171,11 @@ class Experiment(pytest.Item):
         params = {**self.spec, **self.config_params}
         return assign_params(runner_factory, params)()
 
-    def reportinfo(self):
+    def reportinfo(self) -> tuple[Any, int, str]:
         return self.fspath, 0, self.name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f'{self.name}: {self.results}'
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return hasattr(self, 'results')

--- a/pytest_perf/runner.py
+++ b/pytest_perf/runner.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import contextlib
 import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
+from datetime import timedelta
+from typing import Any
 
 import pip_run
 import tempora
@@ -11,7 +16,7 @@ from jaraco.text import strip_ansi
 
 
 class Command(list):
-    def __init__(self, exercise='pass', warmup='pass'):
+    def __init__(self, exercise: str = 'pass', warmup: str = 'pass') -> None:
         self[:] = [
             sys.executable,
             '-s',
@@ -28,41 +33,41 @@ class Result:
     # by default, anything under 100% increase is not significant
     tolerance = 1.0
 
-    def __init__(self, control, experiment):
+    def __init__(self, control: str, experiment: str) -> None:
         self.control_text = control
         self.experiment_text = experiment
 
     @property
-    def delta(self):
+    def delta(self) -> timedelta:
         return self.experiment - self.control
 
     @property
-    def variance(self):
+    def variance(self) -> float:
         try:
             return self.delta / self.control
         except ZeroDivisionError:
             return float('inf') if self.delta else 0
 
     @property
-    def significant(self):
+    def significant(self) -> bool:
         return self.variance > self.tolerance
 
     @property
-    def experiment(self):
+    def experiment(self) -> timedelta:
         return self._parse_timeit_duration(self.experiment_text)
 
     @property
-    def control(self):
+    def control(self) -> timedelta:
         return self._parse_timeit_duration(self.control_text)
 
     @staticmethod
-    def _parse_timeit_duration(time):
+    def _parse_timeit_duration(time: str) -> timedelta:
         return tempora.parse_timedelta(time)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f'{self.experiment} (+{self.delta}, {self.variance:.0%})'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'Result({self.control_text!r}, {self.experiment_text!r})'
 
 
@@ -74,36 +79,43 @@ class BenchmarkRunner:
     Result('...', '...')
     """
 
-    def __init__(self, extras=(), deps=(), control=None):
+    def __init__(
+        self,
+        extras: Iterable[str] = (),
+        deps: Iterable[str] = (),
+        control: str | None = None,
+    ) -> None:
         spec = f'[{",".join(extras)}]' if extras else ''
         self.stack = contextlib.ExitStack()
         self.control_env = self._setup_env(upstream_url(spec, control), *deps)
         self.experiment_env = self._setup_env(f'.{spec}', *deps)
 
-    def _setup_env(self, *deps):
+    def _setup_env(self, *deps: str) -> Any:
         target = self.stack.enter_context(pip_run.deps.load(*deps))
         return pip_run.launch._setup_env(target)
 
-    def run(self, cmd: Command):
+    def run(self, cmd: Command) -> Result:
         experiment = self.eval(cmd, env=self.experiment_env)
         control = self.eval(cmd, env=self.control_env)
         return Result(control, experiment)
 
-    def eval(self, cmd, **kwargs):
+    def eval(self, cmd: Command, **kwargs: Any) -> str:
         with tempfile.TemporaryDirectory() as empty:
             out = subprocess.check_output(
                 cmd, cwd=empty, encoding='utf-8', text=True, **kwargs
             )
         # Python 3.15+ colorizes timeit output when color is enabled (e.g.
         # FORCE_COLOR); strip escape sequences before parsing. jaraco/pytest-perf#20
-        val = re.search(r'([0-9.]+ \w+) per loop', strip_ansi(out)).group(1)
+        val = re.search(  # type: ignore[union-attr] # output always matches
+            r'([0-9.]+ \w+) per loop', strip_ansi(out)
+        ).group(1)
         return val
 
 
 _git_origin = ['git', 'remote', 'get-url', 'origin']
 
 
-def upstream_url(extras='', control=None):
+def upstream_url(extras: str = '', control: str | None = None) -> str:
     """
     >>> getfixture('ensure_checkout')
     >>> upstream_url()
@@ -130,7 +142,7 @@ def upstream_url(extras='', control=None):
     return f'{clean_name}{extras}@git+{origin_url}{rev}'
 
 
-def _ensure_url(origin: str):
+def _ensure_url(origin: str) -> str:
     """
     Convert any implied protocol origins to a SSH URL.
 


### PR DESCRIPTION
Closes #16.

Adds type annotations across the package and a PEP 561 `py.typed` marker, without changing runtime behavior.

## Changes

- **`pytest_perf/deco.py`** — a `_F` TypeVar so the decorators (`decorate`, `control`, and the `extras`/`deps` partials) preserve the decorated function's signature.
- **`pytest_perf/runner.py`** — annotated `Command`, `Result` (properties typed as `timedelta`/`float`/`bool`), `BenchmarkRunner`, and the `upstream_url`/`_ensure_url` helpers.
- **`pytest_perf/plugin.py`** — annotated the pytest hooks (`pytest.Parser`/`Config`/`TerminalReporter`/`Collector`) and the `File`/`Experiment` classes.
- Added `from __future__ import annotations` to all three modules (satisfies the repo's `FA`/`UP` ruff rules).
- **`pytest_perf/py.typed`** — PEP 561 marker; confirmed it lands in the built wheel via setuptools_scm's file-finder.

## Notes

A few `# type: ignore` comments were needed because annotating previously-unchecked function bodies surfaced latent conditions the existing code already handled implicitly — suppression was chosen over restructuring to keep the implementation untouched:

- **`runner.py` `eval`**: `re.search(...).group(1)` — `re.search` may return `None`; the code has always assumed timeit output matches.
- **`plugin.py` `load_module`**: `spec` / `spec.loader` are `Optional` per `importlib` stubs, but the function is wrapped in `@suppress(Exception)`.
- **`plugin.py` `pytest_terminal_summary`**: `items and terminalreporter.section(...)` uses `and` for a side effect; `section` returns `None`.

## Verification

`ruff check`, `ruff format --check`, and `mypy` all clean; runner.py and plugin.py doctests pass under pytest with `pytest-mypy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)